### PR TITLE
admin: Add /readyz endpoint

### DIFF
--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -5,6 +5,7 @@ Version history
 ================
 * access log: added a new flag for upstream retry count exceeded.
 * admin: the admin server can now be accessed via HTTP/2 (prior knowledge).
+* admin: the administration interface now includes a /readyz endpoint for easier readiness checks.
 * buffer: fix vulnerabilities when allocation fails.
 * config: added support of using google.protobuf.Any in opaque configs for extensions.
 * config: removed deprecated --v2-config-only from command line config.

--- a/docs/root/operations/admin.rst
+++ b/docs/root/operations/admin.rst
@@ -222,6 +222,20 @@ modify different aspects of the server:
 See the :ref:`ServerInfo proto <envoy_api_msg_admin.v2alpha.ServerInfo>` for an
 explanation of the output.
 
+.. http:get:: /readyz
+
+  Outputs a string and error code reflecting the state of the server. 200 is returned for the LIVE state,
+  and 503 otherwise. This can be used as a readiness check.
+
+  Example output:
+
+  .. code-block:: none
+
+    LIVE
+
+See the `state` field of the :ref:`ServerInfo proto <envoy_api_msg_admin.v2alpha.ServerInfo>` for an
+explanation of the output.
+
 .. _operations_admin_interface_stats:
 
 .. http:get:: /stats

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1075,7 +1075,7 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
            MAKE_ADMIN_HANDLER(handlerResetCounters), false, true},
           {"/server_info", "print server version/status information",
            MAKE_ADMIN_HANDLER(handlerServerInfo), false, false},
-          {"/readyz", "return 200 if the server state is LIVE, otherwise return 503",
+          {"/readyz", "print server state, return 200 if LIVE, otherwise return 503",
            MAKE_ADMIN_HANDLER(handlerReadyz), false, false},
           {"/stats", "print server stats", MAKE_ADMIN_HANDLER(handlerStats), false, false},
           {"/stats/prometheus", "print server stats in prometheus format",

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -578,6 +578,28 @@ Http::Code AdminImpl::handlerServerInfo(absl::string_view, Http::HeaderMap& head
   return Http::Code::OK;
 }
 
+Http::Code AdminImpl::handlerReadyz(absl::string_view, Http::HeaderMap&,
+                                        Buffer::Instance& response, AdminStream&) {
+  envoy::admin::v2alpha::ServerInfo::State state;
+
+  switch (server_.initManager().state()) {
+  case Init::Manager::State::NotInitialized:
+    state = envoy::admin::v2alpha::ServerInfo::PRE_INITIALIZING;
+    break;
+  case Init::Manager::State::Initializing:
+    state = envoy::admin::v2alpha::ServerInfo::INITIALIZING;
+    break;
+  default:
+    state = server_.healthCheckFailed() ? envoy::admin::v2alpha::ServerInfo::DRAINING
+                                                      : envoy::admin::v2alpha::ServerInfo::LIVE;
+  }
+
+  response.add(envoy::admin::v2alpha::ServerInfo_State_Name(state) + "\n");
+  Http::Code code = state == envoy::admin::v2alpha::ServerInfo_State_LIVE ? Http::Code::OK
+                                                      : Http::Code::ServiceUnavailable;
+  return code;
+}
+
 Http::Code AdminImpl::handlerStats(absl::string_view url, Http::HeaderMap& response_headers,
                                    Buffer::Instance& response, AdminStream& admin_stream) {
   Http::Code rc = Http::Code::OK;
@@ -1053,6 +1075,8 @@ AdminImpl::AdminImpl(const std::string& profile_path, Server::Instance& server)
            MAKE_ADMIN_HANDLER(handlerResetCounters), false, true},
           {"/server_info", "print server version/status information",
            MAKE_ADMIN_HANDLER(handlerServerInfo), false, false},
+          {"/readyz", "return 200 if the server state is LIVE, otherwise return 503",
+           MAKE_ADMIN_HANDLER(handlerReadyz), false, false},
           {"/stats", "print server stats", MAKE_ADMIN_HANDLER(handlerStats), false, false},
           {"/stats/prometheus", "print server stats in prometheus format",
            MAKE_ADMIN_HANDLER(handlerPrometheusStats), false, false},

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -236,6 +236,8 @@ private:
                                   AdminStream&);
   Http::Code handlerServerInfo(absl::string_view path_and_query, Http::HeaderMap& response_headers,
                                Buffer::Instance& response, AdminStream&);
+  Http::Code handlerReadyz(absl::string_view path_and_query, Http::HeaderMap& response_headers,
+                               Buffer::Instance& response, AdminStream&);
   Http::Code handlerStats(absl::string_view path_and_query, Http::HeaderMap& response_headers,
                           Buffer::Instance& response, AdminStream&);
   Http::Code handlerPrometheusStats(absl::string_view path_and_query,

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -148,6 +148,12 @@ TEST_P(IntegrationAdminTest, Admin) {
   EXPECT_STREQ("200", response->headers().Status()->value().c_str());
   EXPECT_STREQ("application/json", ContentType(response));
 
+  response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/readyz", "",
+                                                downstreamProtocol(), version_);
+  EXPECT_TRUE(response->complete());
+  EXPECT_STREQ("200", response->headers().Status()->value().c_str());
+  EXPECT_STREQ("text/plain; charset=UTF-8", ContentType(response));
+
   response = IntegrationUtil::makeSingleRequest(lookupPort("admin"), "GET", "/stats", "",
                                                 downstreamProtocol(), version_);
   EXPECT_TRUE(response->complete());

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1163,6 +1163,42 @@ TEST_P(AdminInstanceTest, GetRequest) {
   EXPECT_EQ(server_info_proto.command_line_options().service_cluster(), "cluster");
 }
 
+TEST_P(AdminInstanceTest, GetReadyzRequest) {
+  NiceMock<Init::MockManager> initManager;
+  ON_CALL(server_, initManager()).WillByDefault(ReturnRef(initManager));
+
+  {
+    Http::HeaderMapImpl response_headers;
+    std::string body;
+
+    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initialized));
+    EXPECT_EQ(Http::Code::OK, admin_.request("/readyz", "GET", response_headers, body));
+    EXPECT_EQ(body, "LIVE\n");
+    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+                HasSubstr("text/plain"));
+  }
+
+  {
+    Http::HeaderMapImpl response_headers;
+    std::string body;
+
+    ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::NotInitialized));
+    EXPECT_EQ(Http::Code::ServiceUnavailable, admin_.request("/readyz", "GET", response_headers, body));
+    EXPECT_EQ(body, "PRE_INITIALIZING\n");
+    EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+                HasSubstr("text/plain"));
+  }
+
+  Http::HeaderMapImpl response_headers;
+  std::string body;
+
+  ON_CALL(initManager, state()).WillByDefault(Return(Init::Manager::State::Initializing));
+  EXPECT_EQ(Http::Code::ServiceUnavailable, admin_.request("/readyz", "GET", response_headers, body));
+  EXPECT_EQ(body, "INITIALIZING\n");
+  EXPECT_THAT(std::string(response_headers.ContentType()->value().getStringView()),
+              HasSubstr("text/plain"));
+}
+
 TEST_P(AdminInstanceTest, GetRequestJson) {
   Http::HeaderMapImpl response_headers;
   std::string body;


### PR DESCRIPTION
*Description*: Adds a `/readyz` endpoint to the administration interface, which responds with a plaintext string according to the value of `state` in the `/server_info` endpoint, and returns either status code 200 if the server is in `LIVE` state, or otherwise a 503. This is intended to make it possible to write Kubernetes readiness checks on envoy containers.
*Risk Level*: Low
*Testing*: This PR includes a new unit test, and an updated integration test.
*Docs Changes*: This PR includes a change to the admin interface docs.
*Release Notes*: Added to v1.10.0 notes, but needs a rebase onto master before I can move it upstream, I think

